### PR TITLE
Edited build-depends for executable test-rdf4h to satisfy use of module T

### DIFF
--- a/rdf4h.cabal
+++ b/rdf4h.cabal
@@ -96,7 +96,7 @@ executable test-rdf4h
     ghc-options:   -Wall
     build-depends: base >= 4 && < 6
                  , test-framework >= 0.2.3 && < 0.3
-                 , test-framework-quickcheck >= 0.2.3 && < 0.3
+                 , test-framework-quickcheck2 >= 0.2.3 && < 0.3
                  , test-framework-hunit >= 0.2.3 && < 0.3
                  , QuickCheck >= 1.2.0.0 && < 1.3
                  , HUnit >= 1.2.2.1 && < 1.3


### PR DESCRIPTION
Edited build-depends for executable test-rdf4h to satisfy use of module Test.Framework.Providers.QuickCheck2 .
